### PR TITLE
Wrapper around Tabletop

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -7,4 +7,5 @@
 <script src="{{ site.baseurl }}/js/vendor/jquery-1.11.3.min.js"></script>
 <script src="{{ site.baseurl }}/js/vendor/lodash.min.js"></script>
 <script src="{{ site.baseurl }}/js/vendor/tabletop.js"></script>
+<script src="{{ site.baseurl }}/js/params.js"></script>
 <script src="{{ site.baseurl }}/js/application.js"></script>

--- a/_includes/js-templates.html
+++ b/_includes/js-templates.html
@@ -1,17 +1,22 @@
 <script type="x/template" id="js-template-jobs_all">
-  <% /* Expects array of jobs */ %>
+  <% /* Expects data to be array of jobs */ %>
   <% _.each(data, function(job){ %>
-  <li class="job" id="<%= job.unique_id %>">
+  <li class="job" id="<%= job.id %>">
     <p class="job__skillset job__skillset--<%= job.job_skillset.toLowerCase().replace(' ','-') %>"><%= job.job_skillset %></p>
     <p class="job__title"><%= job.job_title %></p>
     <p class="job__department"><%= job.job_department %></p>
     <p class="job__organization"><%= job.job_organization %> (<%= job.job_city %>, <%= job.job_state %>)</p>
     <p class="job__summary"><%= job.job_summary %></p>
-    <p class="job__link"><a href="{{ site.baseurl }}/jobs?id=<%= job.unique_id %>" class="button-bold">Learn More</a></p>
+    <p class="job__link"><a href="{{ site.baseurl }}/jobs?id=<%= job.id %>" class="button-bold">Learn More</a></p>
   </li>
   <% }); %>
 </script>
 
 <script type="x/template" id="js-template-jobs_single">
-  <% /* Expects single job object */ %>
+  <% /* Expects data to be a single job object */ 
+     var job = data;
+  %>
+
+  <%= job.job_title %>
+
 </script>

--- a/_includes/js-templates.html
+++ b/_includes/js-templates.html
@@ -1,6 +1,6 @@
 <script type="x/template" id="js-template-jobs_all">
   <% /* Expects array of jobs */ %>
-  <% _.each(jobs, function(job){ %>
+  <% _.each(data, function(job){ %>
   <li class="job" id="<%= job.unique_id %>">
     <p class="job__skillset job__skillset--<%= job.job_skillset.toLowerCase().replace(' ','-') %>"><%= job.job_skillset %></p>
     <p class="job__title"><%= job.job_title %></p>

--- a/_includes/js-templates.html
+++ b/_includes/js-templates.html
@@ -1,0 +1,17 @@
+<script type="x/template" id="js-template-jobs_all">
+  <% /* Expects array of jobs */ %>
+  <% _.each(jobs, function(job){ %>
+  <li class="job" id="<%= job.unique_id %>">
+    <p class="job__skillset job__skillset--<%= job.job_skillset.toLowerCase().replace(' ','-') %>"><%= job.job_skillset %></p>
+    <p class="job__title"><%= job.job_title %></p>
+    <p class="job__department"><%= job.job_department %></p>
+    <p class="job__organization"><%= job.job_organization %> (<%= job.job_city %>, <%= job.job_state %>)</p>
+    <p class="job__summary"><%= job.job_summary %></p>
+    <p class="job__link"><a href="{{ site.baseurl }}/job?id=<%= job.unique_id %>" class="button-bold">Learn More</a></p>
+  </li>
+  <% }); %>
+</script>
+
+<script type="x/template" id="js-template-jobs_single">
+  <% /* Expects single job object */ %>
+</script>

--- a/_includes/js-templates.html
+++ b/_includes/js-templates.html
@@ -7,7 +7,7 @@
     <p class="job__department"><%= job.job_department %></p>
     <p class="job__organization"><%= job.job_organization %> (<%= job.job_city %>, <%= job.job_state %>)</p>
     <p class="job__summary"><%= job.job_summary %></p>
-    <p class="job__link"><a href="{{ site.baseurl }}/job?id=<%= job.unique_id %>" class="button-bold">Learn More</a></p>
+    <p class="job__link"><a href="{{ site.baseurl }}/jobs?id=<%= job.unique_id %>" class="button-bold">Learn More</a></p>
   </li>
   <% }); %>
 </script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -14,4 +14,5 @@
   {{ content }}
   {% include footer.html %}
 </body>
+  {% include js-templates.html %}
 </html>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@ layout: default
   </div>
 
   <div class="jobs">
-    <ul class="unstyled clearfix" id="jobs-app">
+    <ul class="unstyled clearfix" id="js-app-jobs_all">
       <p>Loading... :)</p>
     </ul>
   </div>
@@ -30,25 +30,3 @@ layout: default
           <p class="job__link"><a href="#" class="button-bold">Learn More</a></p>
       </li>
 -->
-
-<script type="x/template" id="js-jobs-template">
-  <% _.each(jobs, function(job){ %>
-    <li class="job" id="<%= job.unique_id %>">
-        <p class="job__skillset job__skillset--<%= job.job_skillset.toLowerCase().replace(' ','-') %>"><%= job.job_skillset %></p>
-        <p class="job__title"><%= job.job_title %></p>
-        <p class="job__department"><%= job.job_department %></p>
-        <p class="job__organization"><%= job.job_organization %> (<%= job.job_city %>, <%= job.job_state %>)</p>
-        <p class="job__summary"><%= job.job_summary %></p>
-        <p class="job__link"><a href="{{ site.baseurl }}/job?id=<%= job.unique_id %>" class="button-bold">Learn More</a></p>
-    </li>
-  <% }); %>
-</script>
-
-<script>
-  $(document).ready(function(){
-    app.init('all_jobs', function(data,template,err){
-      if (err) { throw err; }
-      var template = $('#js-template-all_jobs').html();
-    });
-  });
-</script>

--- a/index.html
+++ b/index.html
@@ -19,14 +19,3 @@ layout: default
     <a class="button" href="#">Submit a job opening</a>
   </div>
 </div>
-
-<!-- 
-      <li class="job">
-          <p class="job__skillset">Designer</p>
-          <p class="job__title">Senior Front End Developer</p>
-          <p class="job__department">Department of Technology</p>
-          <p class="job__organization">City and County of San Francisco (San Francisco, Calif.)</p>
-          <p class="job__summary">Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa um sociis nat.</p>
-          <p class="job__link"><a href="#" class="button-bold">Learn More</a></p>
-      </li>
--->

--- a/index.html
+++ b/index.html
@@ -43,3 +43,12 @@ layout: default
     </li>
   <% }); %>
 </script>
+
+<script>
+  $(document).ready(function(){
+    app.init('all_jobs', function(data,template,err){
+      if (err) { throw err; }
+      var template = $('#js-template-all_jobs').html();
+    });
+  });
+</script>

--- a/jobs/index.html
+++ b/jobs/index.html
@@ -1,0 +1,8 @@
+---
+layout: default
+---
+<div class="layout-large">
+  <div id="js-app-jobs_single">
+    <p>Loading... :)</p>
+  </div>
+</div>

--- a/js/application.js
+++ b/js/application.js
@@ -19,14 +19,14 @@ app.init = function(name,settings) {
     var template,
         compiled,
         result;
-    // Get the data, finish the process
+    // Get the template
+    template = $('#js-template-' + name).html();
+    // Get ready to use the template
+    compiled = _.template(template);
+    // Get the data, fill in the template
     app.get(app.global.sheet_url,app.global.sheet_name,
     function(data,tabletop)
     {
-      // Get the template
-      template = $('#js-template-' + name).html();
-      // Get ready to use the template
-      compiled = _.template(template);
       // Run template and return our HTML
       result = compiled({ 'data' : data });
       // Put the compiled template into the DOM
@@ -52,9 +52,9 @@ app.exists = function(name) {
 // Get the data for the requested sheet, return an array of objects
 // =====
 app.get = function(url,sheet,cb) {
-  console.log('Ring, ring. Calling Google Sheets...')
+  console.log('Ring, ring. Calling Google Sheets...');
   // var goods;
-  return Tabletop.init(
+  Tabletop.init(
   { 
     key: url,
     callback: cb,

--- a/js/application.js
+++ b/js/application.js
@@ -1,9 +1,9 @@
 // =====
 // Set up our app
 // =====
-var app = {},
-    app.global = {};
+var app = {};
     // Global settings
+    app.global = {};
     app.global.sheet_url = 'https://docs.google.com/spreadsheets/d/1O8bcLjf6vapSodOb_zCg445Cr_ctjlRahJRakapKV-Y/pubhtml';
     app.global.sheet_name = 'submitted_jobs';
 
@@ -16,21 +16,23 @@ app.init = function(name,settings) {
     return false;
   }
   if (app.exists(name)) {
-    var data,
-        template,
-        compile,
+    var template,
+        compiled,
         result;
-    // Get the data 
-    data = app.get(app.global.sheet_url,app.global.sheet_name); // Returns array of objects
-    // Get the template
-    template = $('#js-template-' + name).html();
-    // Get ready to use the template
-    compile = _.template(template);
-    // Run template and return our HTML
-    result = compiled({ 'data' : data });
-    // Put the compiled template into the DOM
-    $('#js-app-' + name).html(result);
-    // Return true
+    // Get the data, finish the process
+    app.get(app.global.sheet_url,app.global.sheet_name,
+    function(data,tabletop)
+    {
+      // Get the template
+      template = $('#js-template-' + name).html();
+      // Get ready to use the template
+      compiled = _.template(template);
+      // Run template and return our HTML
+      result = compiled({ 'data' : data });
+      // Put the compiled template into the DOM
+      $('#js-app-' + name).html(result);
+      // Return true
+    });
     return true;
   }
   return false;
@@ -40,7 +42,7 @@ app.init = function(name,settings) {
 // Check if the app exists on the page by finding an ID in the dom in this format: #js-app-name
 // =====
 app.exists = function(name) {
-  if ($('#js-app-' + name) > 0) {
+  if ($('#js-app-' + name).length > 0) {
     return true;
   }
   return false;
@@ -49,28 +51,23 @@ app.exists = function(name) {
 // =====
 // Get the data for the requested sheet, return an array of objects
 // =====
-app.get = function(url,sheet) {
+app.get = function(url,sheet,cb) {
   console.log('Ring, ring. Calling Google Sheets...')
-  var goods;
-  goods = Tabletop.init(
+  // var goods;
+  return Tabletop.init(
   { 
-    key: public_spreadsheet_url,
-    callback: function(data,tabletop) {
-      console.log('They picked up...')
-    },
+    key: url,
+    callback: cb,
     simpleSheet: true 
   });
   // Return the data from the sheet we want
-  return goods.sheets(sheet).elements;
+  // return goods.sheets(sheet).elements;
 }
 
 // =====
 // Run everything
 // =====
-(function(win,doc){
-  // =====
-  // Do the thing
-  // =====
+$(document).ready(function(){
   app.init('jobs_all');
   app.init('jobs_single');
-})(this,this.document);
+});

--- a/js/application.js
+++ b/js/application.js
@@ -1,58 +1,76 @@
-// ======
-// Get the data
-// ======
+// =====
+// Set up our app
+// =====
+var app = {},
+    app.global = {};
+    // Global settings
+    app.global.sheet_url = 'https://docs.google.com/spreadsheets/d/1O8bcLjf6vapSodOb_zCg445Cr_ctjlRahJRakapKV-Y/pubhtml';
+    app.global.sheet_name = 'submitted_jobs';
 
-var public_spreadsheet_url = 'https://docs.google.com/spreadsheets/d/1O8bcLjf6vapSodOb_zCg445Cr_ctjlRahJRakapKV-Y/pubhtml';
+// =====
+// Run the app
+// =====
+app.init = function(name,settings) {
+  if ((!app.global.sheet_url) || (!app.global.sheet_url)) {
+    // Not set up properly!
+    return false;
+  }
+  if (app.exists(name)) {
+    var data,
+        template,
+        compile,
+        result;
+    // Get the data 
+    data = app.get(app.global.sheet_url,app.global.sheet_name); // Returns array of objects
+    // Get the template
+    template = $('#js-template-' + name).html();
+    // Get ready to use the template
+    compile = _.template(template);
+    // Run template and return our HTML
+    result = compiled({ 'data' : data });
+    // Put the compiled template into the DOM
+    $('#js-app-' + name).html(result);
+    // Return true
+    return true;
+  }
+  return false;
+}
 
-function init() {
+// =====
+// Check if the app exists on the page by finding an ID in the dom in this format: #js-app-name
+// =====
+app.exists = function(name) {
+  if ($('#js-app-' + name) > 0) {
+    return true;
+  }
+  return false;
+}
+
+// =====
+// Get the data for the requested sheet, return an array of objects
+// =====
+app.get = function(url,sheet) {
   console.log('Ring, ring. Calling Google Sheets...')
-  Tabletop.init( { key: public_spreadsheet_url,
-                   callback: handleData,
-                   simpleSheet: true } );
-}
-
-function handleData(data,tabletop) {
-  console.log('They picked up...')
-
-  // Pull out the data
-  var jobs;
-  jobs = tabletop.sheets('submitted_jobs').elements;
-  console.log(jobs);
-
-  // Do something with the data
-  makeJobs(jobs);
-}
-
-function makeJobs(jobs) {
-  var template,
-      compiled,
-      conten;
-  template = $('#js-jobs-template').html();
-  compiled = _.template(template);
-  content = compiled({ 'jobs' : jobs });
-  $('#jobs-app').html( content );
-}
-// =====
-// Check if app exists by searching for some class/id in the DOM
-// =====
-
-function appExists(dom) {
-  var exists;
-  exists = $(dom);
-  if (exists.length > 0) { 
-    return true; 
-  }
-  else { 
-    return false; 
-  }
+  var goods;
+  goods = Tabletop.init(
+  { 
+    key: public_spreadsheet_url,
+    callback: function(data,tabletop) {
+      console.log('They picked up...')
+    },
+    simpleSheet: true 
+  });
+  // Return the data from the sheet we want
+  return goods.sheets(sheet).elements;
 }
 
 // =====
-// Do the thing
+// Run everything
 // =====
-
-$(document).ready(function(){
-  if (appExists('#jobs-app')) {
-    init();
-  }
-});
+(function(win,doc){
+  // =====
+  // Do the thing
+  // =====
+  app.init('jobs_all');
+  app.init('jobs_single');
+})(this,this.document);

--- a/js/application.js
+++ b/js/application.js
@@ -6,6 +6,8 @@ var app = {};
     app.global = {};
     app.global.sheet_url = 'https://docs.google.com/spreadsheets/d/1O8bcLjf6vapSodOb_zCg445Cr_ctjlRahJRakapKV-Y/pubhtml';
     app.global.sheet_name = 'submitted_jobs';
+    app.global.errormsg = {};
+    app.global.errormsg.not_found = 'Sorry, that record doesn\'t exists. The record may no longer exist, or you may have the wrong URL.';
 
 // =====
 // Run the app
@@ -23,10 +25,21 @@ app.init = function(name,settings) {
     template = $('#js-template-' + name).html();
     // Get ready to use the template
     compiled = _.template(template);
-    // Get the data, fill in the template
+    // Get the data, fill in the js-templatet
     app.get(app.global.sheet_url,app.global.sheet_name,
     function(data,tabletop)
     {
+      // Do we need to get data by ID?
+      if (typeof settings !== 'undefined') {
+        if (settings.data_id) {
+          data = app.getDataByID(data,settings.data_id);
+          // If that thing doesn't exist, say so
+          if (typeof data === 'undefined') {
+            $('#js-app-' + name).html('<div class="error">' + app.global.errormsg.not_found + '</div>');
+            return;
+          }
+        }
+      }
       // Run template and return our HTML
       result = compiled({ 'data' : data });
       // Put the compiled template into the DOM
@@ -46,6 +59,13 @@ app.exists = function(name) {
     return true;
   }
   return false;
+}
+
+// =====
+// Get the data by ID
+// =====
+app.getDataByID = function(data,id) {
+  return response = _.findWhere(data, { 'id' : id });
 }
 
 // =====
@@ -69,5 +89,7 @@ app.get = function(url,sheet,cb) {
 // =====
 $(document).ready(function(){
   app.init('jobs_all');
-  app.init('jobs_single');
+  app.init('jobs_single',{
+    'data_id' : urlParams.id
+  });
 });

--- a/js/application.js
+++ b/js/application.js
@@ -91,22 +91,12 @@ app.get = function(url,sheet,cb) {
     }
     else {
       console.log('Stale data. Calling Google Sheets...');
-      Tabletop.init(
-      { 
-        key: url,
-        callback: cb,
-        simpleSheet: true 
-      });
+      app.fetch(url,sheet,cb);
     }
   }
   else {
     console.log('Ring, ring. Calling Google Sheets...');
-    Tabletop.init(
-    { 
-      key: url,
-      callback: cb,
-      simpleSheet: true 
-    });
+    app.fetch(url,sheet,cb);
   }
 }
 
@@ -114,8 +104,13 @@ app.get = function(url,sheet,cb) {
 // Reach out to Google Docs
 // =====
 
-app.fetch = function() {
-  
+app.fetch = function(url,sheet,cb) {
+  Tabletop.init(
+  { 
+    key: url,
+    callback: cb,
+    simpleSheet: true 
+  });
 }
 
 // =====

--- a/js/params.js
+++ b/js/params.js
@@ -1,0 +1,13 @@
+// Source: https://github.com/codeforamerica/codeforamerica.org/blob/master/script/params.js
+var urlParams;
+(window.onpopstate = function () {
+    var match,
+        pl     = /\+/g,  // Regex for replacing addition symbol with a space
+        search = /([^&=]+)=?([^&]*)/g,
+        decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); },
+        query  = window.location.search.substring(1);
+
+    urlParams = {};
+    while (match = search.exec(query))
+       urlParams[decode(match[1])] = decode(match[2]);
+})();


### PR DESCRIPTION
Puts a lightweight (and in need of refactoring eventually) wrapper around Tabletop.

Allows us to run `app.init('app_name')` on relevant pages and have everything work quickly.
